### PR TITLE
fix: PRIVATE_TEST read before defined

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -4,6 +4,5 @@
   </div>
 </template>
 <script setup>
-const config = useRuntimeConfig();
-const test = config.PRIVATE_TEST
+const test = process.env.PRIVATE_TEST
 </script>


### PR DESCRIPTION
`privateRuntimeConfig` and `publicRuntimeConfig` are defined at build time.

to use an environment variable that is available only at runtime, read from `process.env`.

this commit will read `process.env.PRIVATE_TEST` just before the `app` component is created.